### PR TITLE
Bugfix: Serialize embedded ressource to empty array if items are null or empty

### DIFF
--- a/src/Hal/Converters/ResourceConverter.cs
+++ b/src/Hal/Converters/ResourceConverter.cs
@@ -144,6 +144,11 @@ namespace Hal.Converters
                                 writer.WriteEndArray();
                             }
                         }
+                        else
+                        {
+                            writer.WriteStartArray();
+                            writer.WriteEndArray();
+                        }
                     }
                 }
                 writer.WriteEndObject();


### PR DESCRIPTION
Without this fix, a runtime error occurs when an embedded ressource with zero items in the Resources collection is serialized:
`Token PropertyName in state Property would result in an invalid JSON object. Path '_embedded'.`