### PR TITLE
Configurable serializer settings

### DIFF
--- a/src/Hal.AspNetCore/HalAspNetCoreExtensions.cs
+++ b/src/Hal.AspNetCore/HalAspNetCoreExtensions.cs
@@ -62,6 +62,21 @@ namespace Hal.AspNetCore
         }
 
         /// <summary>
+        /// Adds the HAL support to the ASP.NET Core application.
+        /// </summary>
+        /// <param name="serviceCollection">The <see cref="IServiceCollection"/> instance to which the HAL support is added.</param>
+        /// <param name="options">The HAL options.</param>
+        /// <param name="jsonSerializerSettings">Json serializer settings.</param>
+        /// <returns>The service collection.</returns>
+        public static IServiceCollection AddHalSupport(this IServiceCollection serviceCollection, Action<SupportsHalOptions> options, Action<JsonSerializerSettings> jsonSerializerSettings)
+        {
+            serviceCollection.Configure(options);
+            serviceCollection.Configure(jsonSerializerSettings);
+            serviceCollection.AddScoped<SupportsHalAttribute>();
+            return serviceCollection;
+        }
+
+        /// <summary>
         /// Adds the HAL support to the ASP.NET Core application with default options.
         /// </summary>
         /// <param name="serviceCollection">The <see cref="IServiceCollection"/> instance to which the HAL support is added.</param>

--- a/src/Hal.AspNetCore/SupportsHalAttribute.cs
+++ b/src/Hal.AspNetCore/SupportsHalAttribute.cs
@@ -48,7 +48,6 @@ using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using System.Collections;
 using System.Dynamic;
-using System.IO;
 using System.Net;
 using System.Reflection;
 using System.Text;
@@ -62,7 +61,7 @@ namespace Hal.AspNetCore
     {
         #region Private Fields
 
-        private static readonly JsonSerializerSettings _jsonSerializerSettings = new()
+        private static readonly JsonSerializerSettings _defaultJsonSerializerSettings = new()
         {
             NullValueHandling = NullValueHandling.Ignore,
             Formatting = Formatting.None,
@@ -72,6 +71,7 @@ namespace Hal.AspNetCore
             }
         };
 
+        private readonly JsonSerializerSettings _jsonSerializerSettings;
         private readonly IUrlHelperFactory _urlHelperFactory;
         private readonly IWebHostEnvironment _hostingEnvironment;
         private readonly ILogger<SupportsHalAttribute> _logger;
@@ -86,7 +86,14 @@ namespace Hal.AspNetCore
         /// </summary>
         /// <param name="options">The options that is used for configuring the HAL support.</param>
         public SupportsHalAttribute(IOptions<SupportsHalOptions> options, ILogger<SupportsHalAttribute> logger, IWebHostEnvironment hostingEnvironment, IUrlHelperFactory urlHelperFactory) =>
-            (Order, _options, _logger, _hostingEnvironment, _urlHelperFactory) = (2, options.Value, logger, hostingEnvironment, urlHelperFactory);
+            (Order, _options, _logger, _hostingEnvironment, _urlHelperFactory, _jsonSerializerSettings) = (2, options.Value, logger, hostingEnvironment, urlHelperFactory, _defaultJsonSerializerSettings);
+
+        /// <summary>
+        /// Initializes a new instance of <c>SupportsHalAttribute</c> class.
+        /// </summary>
+        /// <param name="options">The options that is used for configuring the HAL support.</param>
+        public SupportsHalAttribute(IOptions<SupportsHalOptions> options, ILogger<SupportsHalAttribute> logger, IWebHostEnvironment hostingEnvironment, IUrlHelperFactory urlHelperFactory, JsonSerializerSettings jsonSerializerSettings) =>
+            (Order, _options, _logger, _hostingEnvironment, _urlHelperFactory, _jsonSerializerSettings) = (2, options.Value, logger, hostingEnvironment, urlHelperFactory, jsonSerializerSettings);
 
         #endregion Public Constructors
 

--- a/src/Hal.AspNetCore/SupportsHalAttribute.cs
+++ b/src/Hal.AspNetCore/SupportsHalAttribute.cs
@@ -92,8 +92,9 @@ namespace Hal.AspNetCore
         /// Initializes a new instance of <c>SupportsHalAttribute</c> class.
         /// </summary>
         /// <param name="options">The options that is used for configuring the HAL support.</param>
-        public SupportsHalAttribute(IOptions<SupportsHalOptions> options, ILogger<SupportsHalAttribute> logger, IWebHostEnvironment hostingEnvironment, IUrlHelperFactory urlHelperFactory, JsonSerializerSettings jsonSerializerSettings) =>
-            (Order, _options, _logger, _hostingEnvironment, _urlHelperFactory, _jsonSerializerSettings) = (2, options.Value, logger, hostingEnvironment, urlHelperFactory, jsonSerializerSettings);
+        /// <param name="jsonSerializerSettings">The options that is used for configuring json serializer settings.</param>
+        public SupportsHalAttribute(IOptions<SupportsHalOptions> options, IOptions<JsonSerializerSettings> jsonSerializerSettings, ILogger<SupportsHalAttribute> logger, IWebHostEnvironment hostingEnvironment, IUrlHelperFactory urlHelperFactory) =>
+            (Order, _options, _jsonSerializerSettings, _logger, _hostingEnvironment, _urlHelperFactory) = (2, options.Value, jsonSerializerSettings.Value, logger, hostingEnvironment, urlHelperFactory);
 
         #endregion Public Constructors
 

--- a/src/Hal/Resource.cs
+++ b/src/Hal/Resource.cs
@@ -115,7 +115,7 @@ namespace Hal
         /// <returns>The string representation of the current instance.</returns>
         public string ToString(JsonSerializerSettings jsonSerializerSettings)
         {
-            if (jsonSerializerSettings.Converters == null || jsonSerializerSettings.Converters.Count == 0)
+            if (jsonSerializerSettings.Converters.Count == 0)
                 jsonSerializerSettings.Converters = converters;
             return JsonConvert.SerializeObject(this, jsonSerializerSettings);
         }

--- a/src/Hal/Resource.cs
+++ b/src/Hal/Resource.cs
@@ -115,7 +115,8 @@ namespace Hal
         /// <returns>The string representation of the current instance.</returns>
         public string ToString(JsonSerializerSettings jsonSerializerSettings)
         {
-            jsonSerializerSettings.Converters = converters;
+            if (jsonSerializerSettings.Converters == null || jsonSerializerSettings.Converters.Count == 0)
+                jsonSerializerSettings.Converters = converters;
             return JsonConvert.SerializeObject(this, jsonSerializerSettings);
         }
         #endregion

--- a/tests/Hal.Tests/Converters/ResourceConverterTests.cs
+++ b/tests/Hal.Tests/Converters/ResourceConverterTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Hal.Converters;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using Xunit;
@@ -34,6 +35,40 @@ namespace Hal.Tests.Converters
 
             var expected = new JObject(new JProperty("id", 1234));
             Assert.True(JToken.DeepEquals(expected, result), $"Expected {result} to be equal to {expected}.");
+        }
+
+        [Fact]
+        public void Resource_state_serialization_with_StringEnumConverter_should_convert_enum_as_string()
+        {
+            var serializer = JsonSerializer.Create(new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                ContractResolver = new DefaultContractResolver()
+                {
+                    NamingStrategy = new CamelCaseNamingStrategy()
+                },
+                Converters = new List<JsonConverter>()
+                {
+                    new ResourceConverter(),
+                    new LinkCollectionConverter(),
+                    new LinkConverter(),
+                    new LinkItemCollectionConverter(),
+                    new LinkItemConverter(),
+                    new StringEnumConverter()
+                }
+            });
+            var resource = new Resource(new { Status = Status.Active });
+
+            var result = JToken.FromObject(resource, serializer);
+
+            var expected = new JObject(new JProperty("status", "Active"));
+            Assert.True(JToken.DeepEquals(expected, result), $"Expected {result} to be equal to {expected}.");
+        }
+
+        private enum Status
+        {
+            Active = 0,
+            Inactive = 1
         }
     }
 }


### PR DESCRIPTION
- Added constructor with extra parameter - jsonSerializerSettings. The constructor without this parameter is also available - in such case default settings will be used (as it works now).
- Adjusted logic of assigning JsonSerializerSettings converters. If settings doesn't contain any converters - default ones will be used. If Settings contains any converters they will be used.

These changes will help to solve the following issue: https://github.com/daxnet/hal/issues/24