### PR TITLE
Feat: Add .Resources() to Embedded Builder

### DIFF
--- a/src/Hal/Builders/EmbeddedResourceItemBuilder.cs
+++ b/src/Hal/Builders/EmbeddedResourceItemBuilder.cs
@@ -62,7 +62,7 @@ namespace Hal.Builders
     {
         #region Private Fields
         private readonly string name;
-        private readonly IBuilder resourceBuilder;
+        private readonly IBuilder? resourceBuilder;
         #endregion
 
         #region Ctor        
@@ -72,7 +72,7 @@ namespace Hal.Builders
         /// <param name="context">The context.</param>
         /// <param name="name">The name of the embedded resource collection.</param>
         /// <param name="resourceBuilder">The resource builder that will build the embedded resource.</param>
-        public EmbeddedResourceItemBuilder(IBuilder context, string name, IBuilder resourceBuilder) : base(context)
+        public EmbeddedResourceItemBuilder(IBuilder context, string name, IBuilder? resourceBuilder) : base(context)
         {
             this.name = name;
             this.resourceBuilder = resourceBuilder;
@@ -99,6 +99,12 @@ namespace Hal.Builders
         /// </returns>
         protected override Resource DoBuild(Resource resource)
         {
+            // skip embedded resource if it doesn't exist
+            if (this.resourceBuilder == null)
+            {
+                return resource;
+            }
+
             var embeddedResource = resource.EmbeddedResources?.FirstOrDefault(x => !string.IsNullOrEmpty(x.Name) && x.Name!.Equals(this.name));
             if (embeddedResource == null)
             {

--- a/src/Hal/Builders/Extensions.cs
+++ b/src/Hal/Builders/Extensions.cs
@@ -227,7 +227,10 @@ namespace Hal.Builders
         /// <returns></returns>
         public static IEmbeddedResourceItemBuilder Resources(this IEmbeddedResourceBuilder builder, IEnumerable<IBuilder> resourceBuilders)
         {
-            Contract.Assert(resourceBuilders.Any());
+            if (resourceBuilders.Count() == 0)
+            {
+                return new EmbeddedResourceItemBuilder(builder, builder.Name, null);
+            }
 
             var itemBuilder = new EmbeddedResourceItemBuilder(
                 builder,

--- a/src/Hal/Builders/Extensions.cs
+++ b/src/Hal/Builders/Extensions.cs
@@ -34,6 +34,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
 
 namespace Hal.Builders
 {
@@ -216,6 +218,32 @@ namespace Hal.Builders
         {
             return new EmbeddedResourceItemBuilder(builder, builder.Name, resourceBuilder);
         }
+
+        /// <summary>
+        /// Adds the embedded resources to the embedded resource collection of the building resource.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="resourceBuilders">The enumerable resource builders that will build the embedded resources.</param>
+        /// <returns></returns>
+        public static IEmbeddedResourceItemBuilder Resources(this IEmbeddedResourceBuilder builder, IEnumerable<IBuilder> resourceBuilders)
+        {
+            Contract.Assert(resourceBuilders.Any());
+
+            var itemBuilder = new EmbeddedResourceItemBuilder(
+                builder,
+                builder.Name,
+                resourceBuilders.First()
+            );
+            foreach (var resource in resourceBuilders.Skip(1))
+            {
+                itemBuilder = new EmbeddedResourceItemBuilder(
+                    itemBuilder,
+                    itemBuilder.Name,
+                    resource
+                );
+            }
+            return itemBuilder;
+        }
         #endregion
 
         #region IEmbeddedResourceItemBuilder Extensions
@@ -229,6 +257,22 @@ namespace Hal.Builders
         public static IEmbeddedResourceItemBuilder Resource(this IEmbeddedResourceItemBuilder builder, IBuilder resourceBuilder)
         {
             return new EmbeddedResourceItemBuilder(builder, builder.Name, resourceBuilder);
+        }
+
+        /// <summary>
+        /// Adds the embedded resources to the embedded resource collection of the building resource.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <param name="resourceBuilders">The enumerable resource builders that will build the embedded resources.</param>
+        /// <returns></returns>
+        public static IEmbeddedResourceItemBuilder Resources(this IEmbeddedResourceItemBuilder builder, IEnumerable<IBuilder> resourceBuilders)
+        {
+            // since IEmbeddedResourceBuilder
+            foreach (var resource in resourceBuilders)
+            {
+                builder = builder.Resource(resource);
+            }
+            return builder;
         }
 
         /// <summary>

--- a/tests/Hal.Tests/BuilderTests.cs
+++ b/tests/Hal.Tests/BuilderTests.cs
@@ -93,8 +93,6 @@ namespace Hal.Tests
             var resource = builder.WithState(new { valuesCount = 10, totalsCount = 5 })
                 .AddCuriesLink().WithLinkItem("http://example.com/docs/rels/{rel}", "ea", true)
                 .AddEmbedded("ea:values", false)
-                // TODO: Determine what to do if empty enumerable is passed
-                // and Builder is of type IEmbeddedResourceBuilder
                 .Resources(
                     empty.Select(n => new ResourceBuilder()
                         .WithState(new { id = n })

--- a/tests/Hal.Tests/BuilderTests.cs
+++ b/tests/Hal.Tests/BuilderTests.cs
@@ -1,4 +1,6 @@
-﻿using Hal.Builders;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Hal.Builders;
 using Xunit;
 
 namespace Hal.Tests
@@ -50,5 +52,63 @@ namespace Hal.Tests
                 .WithState(state);
             var json = builder.Build().ToString();
         }
+
+        [Fact]
+        public void BuilderTest4()
+        {
+            int[] firstList = Enumerable.Range(1, 5).ToArray();
+            HashSet<int> secondList = Enumerable.Range(6, 5).ToHashSet();
+            int[] empty = [];
+            int[] single = [1];
+
+            var builder = new ResourceBuilder();
+            var resource = builder.WithState(new { valuesCount = 10, totalsCount = 5 })
+                .AddCuriesLink().WithLinkItem("http://example.com/docs/rels/{rel}", "ea", true)
+                .AddEmbedded("ea:values", true)
+                .Resources(
+                    firstList.Select(n => new ResourceBuilder()
+                        .WithState(new { id = n })
+                        .AddSelfLink().WithLinkItem($"/values/{n}")
+                    )
+                )
+                .Resources(
+                    secondList.Select(n => new ResourceBuilder()
+                        .WithState(new { Id = n })
+                        .AddSelfLink().WithLinkItem($"/values/{n}"))
+                )
+                .Resources(empty.Select(n => new ResourceBuilder()
+                        .WithState(new { total = n })
+                        .AddSelfLink().WithLinkItem($"/totals/{n}")
+                    )
+                );
+            var json = resource.Build().ToString();
+        }
+        [Fact]
+        public void BuilderTest5()
+        {
+            int[] empty = [];
+            int[] single = [1];
+
+            var builder = new ResourceBuilder();
+            var resource = builder.WithState(new { valuesCount = 10, totalsCount = 5 })
+                .AddCuriesLink().WithLinkItem("http://example.com/docs/rels/{rel}", "ea", true)
+                .AddEmbedded("ea:values", false)
+                // TODO: Determine what to do if empty enumerable is passed
+                // and Builder is of type IEmbeddedResourceBuilder
+                .Resources(
+                    empty.Select(n => new ResourceBuilder()
+                        .WithState(new { id = n })
+                        .AddSelfLink().WithLinkItem($"/values/{n}")
+                    )
+                )
+                .AddEmbedded("ea:totals", false)
+                .Resources(
+                    single.Select(n => new ResourceBuilder()
+                        .WithState(new { Id = n })
+                        .AddSelfLink().WithLinkItem($"/totals/{n}"))
+                );
+            var json = resource.Build().ToString();
+        }
     }
 }
+


### PR DESCRIPTION
Feature:
* Add IEmbeddedResourceBuilder#Resources()
* Add IEmbeddedResourceItemBuilder#Resources()

This allows you to pass an Enumerable<IBuilder> to add to the
embedded resource.

As of this commit, the method will crash if the passed
Enumerable is empty. This is because the .Resource()
method returns IEmbeddedResourceItemBuilder
instead of IEmbeddedResourceBuilder. That prevents
exiting early if the passed Enumerable is empty because
the current builder's type does not match.

closes #31